### PR TITLE
footer_fix&aseet_path

### DIFF
--- a/app/assets/stylesheets/footer.scss
+++ b/app/assets/stylesheets/footer.scss
@@ -1,51 +1,51 @@
-.footer{
+.main-footer {
   padding: 60px 0;
   color: #fff;
   background-color: #272727;
   text-align: center;
-  .contents{
+  &__contents {
     max-width: 840px;
     margin: 0 auto;
     display: flex;
-    .content{
+    &__content {
       display: flex;
       flex-direction: column;
       width: calc(1 / 3 * 100%);
       margin: 0 2% 0 0;
-      .content__header{
+      &__content__header{
         margin: 0 0 20px;
         font-size: 16px;
         font-weight: bold;
       }
-      ul{
+      &__about {
         list-style: none;
-        li{
+        &__over-view {
           margin: 0;
           padding: 0;
-          a{
+        }
+        &__over-view a{
             display: block;
             color: #fff;
             text-decoration: none;
             font-size: 12px;
             line-height: 32px;
           }
-        }
       }
     }
   }
-  .footer-logo{
+  &__footer-logo {
     max-width: 160px;
     width: 100%;
     margin: 0 auto;
-    a{
+    a {
       box-sizing: border-box;
     }
-    img{
+    img {
       width: 100%;
       vertical-align: bottom;
     }
   }
-  .p{
-    font-size: 14px;
+  &__copyright {
+    font-size: 12px;
   }
 }

--- a/app/views/items/_footer.html.haml
+++ b/app/views/items/_footer.html.haml
@@ -1,10 +1,10 @@
-.footer
-  %ul.contents
-    %li.content
-      %h2.content__header
+%footer.main-footer
+  %ul.main-footer__contents
+    %li.main-footer__contents__content
+      %h2.main-footer__contents__content__header
         FURIMAについて
-      %ul
-        %li
+      %ul.main-footer__contents__content__about
+        %li.main-footer__contents__content__about__over-view
           = link_to "#" do
             会社概要（運営会社）
           = link_to "#" do
@@ -13,28 +13,29 @@
             FURIMA利用規約
           = link_to "#" do
             ポイントに関する特約
-    %li.content
-      %h2.content__header
+
+    %li.main-footer__contents__content
+      %h2.main-footer__contents__content__header
         FURIMAを見る
-      %ul
-        %li
+      %ul.main-footer__contents__content__about
+        %li.main-footer__contents__content__about__over-view
           = link_to "#" do
             カテゴリー一覧
           = link_to "#" do
             ブランド一覧
-    %li.content
-      %h2.content__header
+
+    %li.main-footer__contents__content
+      %h2.main-footer__contents__content__header
         ヘルプ&ガイド
-      %ul
-        %li
+      %ul.main-footer__contents__content__about
+        %li.main-footer__contents__content__about__over-view
           = link_to "#" do
             FURIMAガイド
           = link_to "#" do
             FURIMAロゴ利用ガイドライン
           = link_to "#" do
             お知らせ
-  .footer-logo
-    = link_to ""
-    = image_tag '/assets/material/logo/logo-white.png'
-  %p
-    © FURIMA
+  .main-footer__footer-logo
+    = image_tag asset_path("material/logo/logo-white.png")
+    %p.main-footer__footer-logo__copy-right
+      © FURIMA

--- a/app/views/items/_main.html.haml
+++ b/app/views/items/_main.html.haml
@@ -187,7 +187,6 @@
             %p.main__pickup-category__product-box__lists__list__body__details__tax
               (税込)
 
-
 .main__exisibition
   %span.main__exisibition__text
     出品する

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -8,14 +8,14 @@
           .main__show-main__content-right__top-content__item-box__body
             %ul.main_image
               %li.main_photo
-                = image_tag 'material/show/main.png', size: "560x346"
+                = image_tag asset_path('material/show/main.png'), size: "560x346"
                 %ul.show_index
                   %li.show_index__content
-                    = image_tag 'material/show/index1.png', size: "130x87", class: "png"
+                    = image_tag asset_path('material/show/index1.png'), size: "130x87", class: "png"
                   %li.show_index__content
-                    = image_tag 'material/show/index2.png', size: "130x87", class: "png"
+                    = image_tag asset_path('material/show/index2.png'), size: "130x87", class: "png"
                   %li.show_index__content
-                    = image_tag 'material/show/index3.png', size: "130x87", class: "png"
+                    = image_tag asset_path('material/show/index3.png'), size: "130x87", class: "png"
 
           .main__show-main__content-right__top-content__item-box__price
             %span.font-size ¥30000


### PR DESCRIPTION
フッター部分の修正＆ image_tagの修正。

フッター部分がBEMの命名規則に沿っていなかったのと、ビュー崩れがみられたため修正を行なった。
前回のコミットと同様に、アセットパイプライン対策にimage_tagの修正を行なった。
= image_tag "material/logo/logo-white.png"
↓
= image_tag asset_path("material/logo/logo-white.png")